### PR TITLE
Update sequelize define use predefined tableName.

### DIFF
--- a/server2/src/models/authapi_user.js
+++ b/server2/src/models/authapi_user.js
@@ -61,6 +61,7 @@ module.exports = (sequelize, DataTypes) => {
       paranoid: true,
       charset:'utf8',
       collate:'utf8_general_ci',
+      tableName:'authapi_user',
     })
     return authapi_user;
 };


### PR DESCRIPTION
<img width="344" alt="스크린샷 2020-11-24 오후 2 51 59" src="https://user-images.githubusercontent.com/59718913/100054060-abde1e00-2e64-11eb-994d-591ef7f2973d.png">
<img width="1495" alt="스크린샷 2020-11-24 오후 2 52 13" src="https://user-images.githubusercontent.com/59718913/100054066-ad0f4b00-2e64-11eb-8f8a-8e2b37e4bf54.png">

- 전 table을 따로 생성하지 않않고 insert시도로 sql문을 뽑아보았는데요. tableName에서 s가 빠졌습니다.

- 사실 s를 빼는건 (auto-pluralization off),  `freezeTableName: true` 로 된다고 하는데요. 사실 기존에 생성된거랑 매칭하는 것이기 때문에 tableName으로 접근하는게 맞는 것 같습니다.

아래 섹션을 참고하세요.
https://sequelize.org/master/manual/model-basics.html
- Enforcing the table name to be equal to the model name
- Providing the table name directly

추가로 id/createdAt/updatedAt 없이 (그러니까 insert할 생각 없이 그냥 사용만 할거라면)
[sequelize 에서 사전에 작성된 테이블 사용시 모델 작성방법](https://ivorycirrus.github.io/TIL/node-sequelize-model/)
이거를 참고해주세요.